### PR TITLE
Eliminatemock object redundancy

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
@@ -53,7 +53,8 @@ import static org.mockito.Mockito.when;
  *
  */
 public class DispatcherHasNoSubscribersTests {
-
+	final ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+	final Connection connection = mock(Connection.class);
 	@Test
 	public void testPtP() throws Exception {
 		final Channel channel = mock(Channel.class);
@@ -61,9 +62,7 @@ public class DispatcherHasNoSubscribersTests {
 		when(declareOk.getQueue()).thenReturn("noSubscribersChannel");
 		when(channel.queueDeclare(anyString(), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
 				.thenReturn(declareOk);
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> channel).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -85,9 +84,7 @@ public class DispatcherHasNoSubscribersTests {
 	@Test
 	public void testPubSub() {
 		final Channel channel = mock(Channel.class);
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> channel).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
@@ -86,6 +86,8 @@ import static org.mockito.Mockito.when;
 @SpringJUnitConfig
 @DirtiesContext
 public class AmqpOutboundChannelAdapterParserTests {
+	final Channel mockChannel = mock(Channel.class);
+	final Connection mockConnection = mock(Connection.class);
 
 	private static volatile int adviceCalled;
 
@@ -244,8 +246,6 @@ public class AmqpOutboundChannelAdapterParserTests {
 	@Test
 	public void testInt2773UseDefaultAmqpTemplateExchangeAndRoutingLey() throws IOException {
 		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
-		Connection mockConnection = mock(Connection.class);
-		Channel mockChannel = mock(Channel.class);
 
 		when(connectionFactory.createConnection()).thenReturn(mockConnection);
 		PublisherCallbackChannelImpl publisherCallbackChannel = new PublisherCallbackChannelImpl(mockChannel,
@@ -262,8 +262,6 @@ public class AmqpOutboundChannelAdapterParserTests {
 	@Test
 	public void testInt2773WithDefaultAmqpTemplateExchangeAndRoutingKey() throws IOException {
 		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
-		Connection mockConnection = mock(Connection.class);
-		Channel mockChannel = mock(Channel.class);
 
 		when(connectionFactory.createConnection()).thenReturn(mockConnection);
 		PublisherCallbackChannelImpl publisherCallbackChannel = new PublisherCallbackChannelImpl(mockChannel,
@@ -280,8 +278,6 @@ public class AmqpOutboundChannelAdapterParserTests {
 	@Test
 	public void testInt2773WithOverrideToDefaultAmqpTemplateExchangeAndRoutingLey() throws IOException {
 		ConnectionFactory connectionFactory = context.getBean(ConnectionFactory.class);
-		Connection mockConnection = mock(Connection.class);
-		Channel mockChannel = mock(Channel.class);
 
 		when(connectionFactory.createConnection()).thenReturn(mockConnection);
 		PublisherCallbackChannelImpl publisherCallbackChannel = new PublisherCallbackChannelImpl(mockChannel,

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpMessageSourceTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpMessageSourceTests.java
@@ -53,10 +53,10 @@ import static org.mockito.Mockito.verify;
  *
  */
 public class AmqpMessageSourceTests {
-
+	final Channel channel = mock(Channel.class);
+	
 	@Test
 	public void testAck() throws Exception {
-		Channel channel = mock(Channel.class);
 		willReturn(true).given(channel).isOpen();
 		Envelope envelope = new Envelope(123L, false, "ex", "rk");
 		BasicProperties props = new BasicProperties.Builder().build();
@@ -104,7 +104,6 @@ public class AmqpMessageSourceTests {
 	}
 
 	private void testNackOrRequeue(boolean requeue) throws Exception {
-		Channel channel = mock(Channel.class);
 		willReturn(true).given(channel).isOpen();
 		Envelope envelope = new Envelope(123L, false, "ex", "rk");
 		BasicProperties props = new BasicProperties.Builder().build();
@@ -141,7 +140,6 @@ public class AmqpMessageSourceTests {
 		message = new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties);
 		MessageBatch batched = bs.addToBatch("foo", "bar", message);
 
-		Channel channel = mock(Channel.class);
 		willReturn(true).given(channel).isOpen();
 		Envelope envelope = new Envelope(123L, false, "ex", "rk");
 		BasicProperties props = new BasicProperties.Builder()

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
@@ -88,10 +88,12 @@ import static org.mockito.Mockito.when;
  */
 public class InboundEndpointTests {
 	final ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+	final Channel rabbitChannel = mock(Channel.class);
+	final Channel channel = mock(Channel.class);
+	final Connection connection = mock(Connection.class);
 	
 	@Test
 	public void testInt2809JavaTypePropertiesToAmqp() throws Exception {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
@@ -120,7 +122,6 @@ public class InboundEndpointTests {
 		DefaultAmqpHeaderMapper.inboundMapper().fromHeadersToRequest(jsonMessage.getHeaders(), amqpMessageProperties);
 
 		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
-		Channel rabbitChannel = mock(Channel.class);
 		listener.onMessage(amqpMessage, rabbitChannel);
 
 		Message<?> result = channel.receive(1000);
@@ -134,7 +135,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testInt2809JavaTypePropertiesFromAmqp() throws Exception {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
@@ -168,7 +168,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testMessageConverterJsonHeadersHavePrecedenceOverMessageHeaders() throws Exception {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
@@ -176,8 +175,6 @@ public class InboundEndpointTests {
 		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
 
 		DirectChannel channel = new DirectChannel();
-
-		final Channel rabbitChannel = mock(Channel.class);
 
 		channel.subscribe(new MessageTransformingHandler(message -> {
 			assertThat(message.getHeaders().get(AmqpHeaders.CHANNEL)).isSameAs(rabbitChannel);
@@ -233,7 +230,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testAdapterConversionError() throws Exception {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
@@ -266,7 +262,6 @@ public class InboundEndpointTests {
 
 		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
 		adapter.afterPropertiesSet(); // ack mode is now captured during init
-		Channel channel = mock(Channel.class);
 		((ChannelAwareMessageListener) container.getMessageListener())
 				.onMessage(message, channel);
 		assertThat(outputChannel.receive(0)).isNull();
@@ -282,7 +277,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testGatewayConversionError() throws Exception {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
@@ -319,7 +313,6 @@ public class InboundEndpointTests {
 		assertThat(received.getHeaders().get(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE)).isNotNull();
 
 		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
-		Channel channel = mock(Channel.class);
 		((ChannelAwareMessageListener) container.getMessageListener())
 				.onMessage(message, channel);
 		assertThat(outputChannel.receive(0)).isNull();
@@ -579,7 +572,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testAdapterConversionErrorConsumerBatchExtract() {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
@@ -619,7 +611,6 @@ public class InboundEndpointTests {
 
 		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
 		adapter.afterPropertiesSet(); // ack mode is now captured during init
-		Channel channel = mock(Channel.class);
 		((ChannelAwareBatchMessageListener) container.getMessageListener())
 				.onMessageBatch(messages, channel);
 		assertThat(outputChannel.receive(0)).isNull();
@@ -635,7 +626,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testAdapterConversionErrorConsumerBatch() {
-		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
@@ -674,7 +664,6 @@ public class InboundEndpointTests {
 
 		container.setAcknowledgeMode(AcknowledgeMode.MANUAL);
 		adapter.afterPropertiesSet(); // ack mode is now captured during init
-		Channel channel = mock(Channel.class);
 		((ChannelAwareBatchMessageListener) container.getMessageListener())
 				.onMessageBatch(messages, channel);
 		assertThat(outputChannel.receive(0)).isNull();

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
@@ -87,12 +87,12 @@ import static org.mockito.Mockito.when;
  * @since 3.0
  */
 public class InboundEndpointTests {
-
+	final ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+	
 	@Test
 	public void testInt2809JavaTypePropertiesToAmqp() throws Exception {
 		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -136,7 +136,6 @@ public class InboundEndpointTests {
 	public void testInt2809JavaTypePropertiesFromAmqp() throws Exception {
 		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -171,7 +170,6 @@ public class InboundEndpointTests {
 	public void testMessageConverterJsonHeadersHavePrecedenceOverMessageHeaders() throws Exception {
 		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -237,7 +235,6 @@ public class InboundEndpointTests {
 	public void testAdapterConversionError() throws Exception {
 		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -287,7 +284,6 @@ public class InboundEndpointTests {
 	public void testGatewayConversionError() throws Exception {
 		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -339,7 +335,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testRetryWithinOnMessageAdapter() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
 		adapter.setOutputChannel(new DirectChannel());
@@ -367,7 +362,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testRetryWithMessageRecovererOnMessageAdapter() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
 		adapter.setOutputChannel(new DirectChannel());
@@ -400,7 +394,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testRetryWithinOnMessageGateway() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		AmqpInboundGateway adapter = new AmqpInboundGateway(container);
 		adapter.setRequestChannel(new DirectChannel());
@@ -428,7 +421,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testRetryWithMessageRecovererOnMessageGateway() throws Exception {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		AmqpInboundGateway adapter = new AmqpInboundGateway(container);
 		adapter.setRequestChannel(new DirectChannel());
@@ -589,7 +581,6 @@ public class InboundEndpointTests {
 	public void testAdapterConversionErrorConsumerBatchExtract() {
 		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -646,7 +637,6 @@ public class InboundEndpointTests {
 	public void testAdapterConversionErrorConsumerBatch() {
 		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		when(connectionFactory.createConnection()).thenReturn(connection);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
 		container.setConnectionFactory(connectionFactory);
@@ -700,7 +690,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testRetryWithinOnMessageAdapterConsumerBatch() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		container.setConsumerBatchEnabled(true);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
@@ -746,7 +735,6 @@ public class InboundEndpointTests {
 
 	@Test
 	public void testRetryWithMessageRecovererOnMessageAdapterConsumerBatch() throws InterruptedException {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		container.setConsumerBatchEnabled(true);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/OutboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/OutboundEndpointTests.java
@@ -60,10 +60,10 @@ import static org.mockito.Mockito.verify;
  * @since 3.0
  */
 public class OutboundEndpointTests {
+	final ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 
 	@Test
 	public void testDelayExpression() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		RabbitTemplate amqpTemplate = spy(new RabbitTemplate(connectionFactory));
 		AmqpOutboundEndpoint endpoint = new AmqpOutboundEndpoint(amqpTemplate);
 		willDoNothing()
@@ -96,7 +96,6 @@ public class OutboundEndpointTests {
 
 	@Test
 	public void testAsyncDelayExpression() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		AsyncRabbitTemplate amqpTemplate = spy(new AsyncRabbitTemplate(new RabbitTemplate(connectionFactory),
 				new SimpleMessageListenerContainer(connectionFactory), "replyTo"));
 		amqpTemplate.setTaskScheduler(mock(TaskScheduler.class));
@@ -119,7 +118,6 @@ public class OutboundEndpointTests {
 
 	@Test
 	public void testHeaderMapperWinsAdapter() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		RabbitTemplate amqpTemplate = spy(new RabbitTemplate(connectionFactory));
 		AmqpOutboundEndpoint endpoint = new AmqpOutboundEndpoint(amqpTemplate);
 		endpoint.setHeadersMappedLast(true);
@@ -138,7 +136,6 @@ public class OutboundEndpointTests {
 
 	@Test
 	public void testHeaderMapperWinsGateway() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		TestRabbitTemplate amqpTemplate = spy(new TestRabbitTemplate(connectionFactory));
 		amqpTemplate.setUseTemporaryReplyQueues(true);
 		AmqpOutboundEndpoint endpoint = new AmqpOutboundEndpoint(amqpTemplate);
@@ -165,7 +162,6 @@ public class OutboundEndpointTests {
 
 	@Test
 	public void testReplyHeadersWin() {
-		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		TestRabbitTemplate amqpTemplate = spy(new TestRabbitTemplate(connectionFactory));
 		amqpTemplate.setUseTemporaryReplyQueues(true);
 		AmqpOutboundEndpoint endpoint = new AmqpOutboundEndpoint(amqpTemplate);

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/DispatcherHasNoSubscribersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,82 +14,125 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.channel;
+package org.springframework.integration.amqp.channel;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import java.util.ArrayList;
+import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.support.AbstractApplicationContext;
-import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.MessagingException;
-import org.springframework.messaging.support.GenericMessage;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import com.rabbitmq.client.AMQP.Queue.DeclareOk;
+import com.rabbitmq.client.Channel;
+import org.apache.commons.logging.Log;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageListener;
+import org.springframework.amqp.rabbit.connection.Connection;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.messaging.MessageDeliveryException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.1
  *
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
 public class DispatcherHasNoSubscribersTests {
+	final ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+	final Connection connection = mock(Connection.class);
+	@Test
+	public void testPtP() throws Exception {
+		final Channel channel = mock(Channel.class);
+		DeclareOk declareOk = mock(DeclareOk.class);
+		when(declareOk.getQueue()).thenReturn("noSubscribersChannel");
+		when(channel.queueDeclare(anyString(), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
+				.thenReturn(declareOk);
+		doAnswer(invocation -> channel).when(connection).createChannel(anyBoolean());
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
 
-	@Autowired
-	MessageChannel noSubscribersChannel;
+		PointToPointSubscribableAmqpChannel amqpChannel =
+				new PointToPointSubscribableAmqpChannel("noSubscribersChannel", container, amqpTemplate);
+		amqpChannel.setBeanName("noSubscribersChannel");
+		amqpChannel.setBeanFactory(mock(BeanFactory.class));
+		amqpChannel.afterPropertiesSet();
 
-	@Autowired
-	MessageChannel subscribedChannel;
+		MessageListener listener = container.getMessageListener();
 
-	@Autowired
-	AbstractApplicationContext applicationContext;
-
-	@Before
-	public void setup() {
-		applicationContext.setId("foo");
+		assertThatExceptionOfType(MessageDeliveryException.class)
+				.isThrownBy(() -> listener.onMessage(new Message("Hello world!".getBytes())))
+				.withMessageContaining("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'.");
 	}
 
 	@Test
-	public void oneChannel() {
-		try {
-			noSubscribersChannel.send(new GenericMessage<String>("Hello, world!"));
-			fail("Exception expected");
-		}
-		catch (MessagingException e) {
-			assertThat(e.getMessage())
-					.contains("Dispatcher has no subscribers for channel 'foo.noSubscribersChannel'.");
-		}
+	public void testPubSub() {
+		final Channel channel = mock(Channel.class);
+		doAnswer(invocation -> channel).when(connection).createChannel(anyBoolean());
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+		container.setConnectionFactory(connectionFactory);
+		AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
+		PublishSubscribeAmqpChannel amqpChannel =
+				new PublishSubscribeAmqpChannel("noSubscribersChannel", container, amqpTemplate);
+		amqpChannel.setBeanName("noSubscribersChannel");
+		amqpChannel.setBeanFactory(mock(BeanFactory.class));
+		amqpChannel.afterPropertiesSet();
+
+		List<String> logList = insertMockLoggerInListener(amqpChannel);
+		MessageListener listener = container.getMessageListener();
+		listener.onMessage(new Message("Hello world!".getBytes()));
+		verifyLogReceived(logList);
 	}
 
-	@Test
-	public void stackedChannels() {
-		try {
-			subscribedChannel.send(new GenericMessage<String>("Hello, world!"));
-			fail("Exception expected");
-		}
-		catch (MessagingException e) {
-			assertThat(e.getMessage())
-					.contains("Dispatcher has no subscribers for channel 'foo.noSubscribersChannel'.");
-		}
+	private static List<String> insertMockLoggerInListener(PublishSubscribeAmqpChannel channel) {
+		SimpleMessageListenerContainer container =
+				TestUtils.getPropertyValue(channel, "container", SimpleMessageListenerContainer.class);
+		Log logger = mock(Log.class);
+		final ArrayList<String> logList = new ArrayList<>();
+		doAnswer(invocation -> {
+			String message = invocation.getArgument(0);
+			if (message.startsWith("Dispatcher has no subscribers")) {
+				logList.add(message);
+			}
+			return null;
+		}).when(logger).warn(anyString(), any(Exception.class));
+		when(logger.isWarnEnabled()).thenReturn(true);
+		Object listener = container.getMessageListener();
+		DirectFieldAccessor dfa = new DirectFieldAccessor(listener);
+		dfa.setPropertyValue("logger", logger);
+		return logList;
 	}
 
-	@Test
-	public void withNoContext() {
-		DirectChannel channel = new DirectChannel();
-		channel.setBeanName("bar");
-		try {
-			channel.send(new GenericMessage<String>("Hello, world!"));
-			fail("Exception expected");
+	private static void verifyLogReceived(final List<String> logList) {
+		assertThat(logList.size() > 0).as("Failed to get expected exception").isTrue();
+		boolean expectedExceptionFound = false;
+		while (logList.size() > 0) {
+			String message = logList.remove(0);
+			assertThat(message).as("Failed to get expected exception").isNotNull();
+			if (message.startsWith("Dispatcher has no subscribers")) {
+				expectedExceptionFound = true;
+				assertThat(message).contains("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'.");
+				break;
+			}
 		}
-		catch (MessagingException e) {
-			assertThat(e.getMessage()).contains("Dispatcher has no subscribers for channel 'bar'.");
-		}
+		assertThat(expectedExceptionFound).as("Failed to get expected exception").isTrue();
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/DispatcherHasNoSubscribersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,125 +14,82 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.amqp.channel;
+package org.springframework.integration.channel;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import com.rabbitmq.client.AMQP.Queue.DeclareOk;
-import com.rabbitmq.client.Channel;
-import org.apache.commons.logging.Log;
-import org.junit.jupiter.api.Test;
-
-import org.springframework.amqp.core.AmqpTemplate;
-import org.springframework.amqp.core.Message;
-import org.springframework.amqp.core.MessageListener;
-import org.springframework.amqp.rabbit.connection.Connection;
-import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
-import org.springframework.beans.DirectFieldAccessor;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.integration.test.util.TestUtils;
-import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Gary Russell
  * @author Artem Bilan
- *
  * @since 2.1
  *
  */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
 public class DispatcherHasNoSubscribersTests {
-	final ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
-	final Connection connection = mock(Connection.class);
-	@Test
-	public void testPtP() throws Exception {
-		final Channel channel = mock(Channel.class);
-		DeclareOk declareOk = mock(DeclareOk.class);
-		when(declareOk.getQueue()).thenReturn("noSubscribersChannel");
-		when(channel.queueDeclare(anyString(), anyBoolean(), anyBoolean(), anyBoolean(), isNull()))
-				.thenReturn(declareOk);
-		doAnswer(invocation -> channel).when(connection).createChannel(anyBoolean());
-		when(connectionFactory.createConnection()).thenReturn(connection);
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
-		container.setConnectionFactory(connectionFactory);
-		AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
 
-		PointToPointSubscribableAmqpChannel amqpChannel =
-				new PointToPointSubscribableAmqpChannel("noSubscribersChannel", container, amqpTemplate);
-		amqpChannel.setBeanName("noSubscribersChannel");
-		amqpChannel.setBeanFactory(mock(BeanFactory.class));
-		amqpChannel.afterPropertiesSet();
+	@Autowired
+	MessageChannel noSubscribersChannel;
 
-		MessageListener listener = container.getMessageListener();
+	@Autowired
+	MessageChannel subscribedChannel;
 
-		assertThatExceptionOfType(MessageDeliveryException.class)
-				.isThrownBy(() -> listener.onMessage(new Message("Hello world!".getBytes())))
-				.withMessageContaining("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'.");
+	@Autowired
+	AbstractApplicationContext applicationContext;
+
+	@Before
+	public void setup() {
+		applicationContext.setId("foo");
 	}
 
 	@Test
-	public void testPubSub() {
-		final Channel channel = mock(Channel.class);
-		doAnswer(invocation -> channel).when(connection).createChannel(anyBoolean());
-		when(connectionFactory.createConnection()).thenReturn(connection);
-		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
-		container.setConnectionFactory(connectionFactory);
-		AmqpTemplate amqpTemplate = mock(AmqpTemplate.class);
-		PublishSubscribeAmqpChannel amqpChannel =
-				new PublishSubscribeAmqpChannel("noSubscribersChannel", container, amqpTemplate);
-		amqpChannel.setBeanName("noSubscribersChannel");
-		amqpChannel.setBeanFactory(mock(BeanFactory.class));
-		amqpChannel.afterPropertiesSet();
-
-		List<String> logList = insertMockLoggerInListener(amqpChannel);
-		MessageListener listener = container.getMessageListener();
-		listener.onMessage(new Message("Hello world!".getBytes()));
-		verifyLogReceived(logList);
-	}
-
-	private static List<String> insertMockLoggerInListener(PublishSubscribeAmqpChannel channel) {
-		SimpleMessageListenerContainer container =
-				TestUtils.getPropertyValue(channel, "container", SimpleMessageListenerContainer.class);
-		Log logger = mock(Log.class);
-		final ArrayList<String> logList = new ArrayList<>();
-		doAnswer(invocation -> {
-			String message = invocation.getArgument(0);
-			if (message.startsWith("Dispatcher has no subscribers")) {
-				logList.add(message);
-			}
-			return null;
-		}).when(logger).warn(anyString(), any(Exception.class));
-		when(logger.isWarnEnabled()).thenReturn(true);
-		Object listener = container.getMessageListener();
-		DirectFieldAccessor dfa = new DirectFieldAccessor(listener);
-		dfa.setPropertyValue("logger", logger);
-		return logList;
-	}
-
-	private static void verifyLogReceived(final List<String> logList) {
-		assertThat(logList.size() > 0).as("Failed to get expected exception").isTrue();
-		boolean expectedExceptionFound = false;
-		while (logList.size() > 0) {
-			String message = logList.remove(0);
-			assertThat(message).as("Failed to get expected exception").isNotNull();
-			if (message.startsWith("Dispatcher has no subscribers")) {
-				expectedExceptionFound = true;
-				assertThat(message).contains("Dispatcher has no subscribers for amqp-channel 'noSubscribersChannel'.");
-				break;
-			}
+	public void oneChannel() {
+		try {
+			noSubscribersChannel.send(new GenericMessage<String>("Hello, world!"));
+			fail("Exception expected");
 		}
-		assertThat(expectedExceptionFound).as("Failed to get expected exception").isTrue();
+		catch (MessagingException e) {
+			assertThat(e.getMessage())
+					.contains("Dispatcher has no subscribers for channel 'foo.noSubscribersChannel'.");
+		}
+	}
+
+	@Test
+	public void stackedChannels() {
+		try {
+			subscribedChannel.send(new GenericMessage<String>("Hello, world!"));
+			fail("Exception expected");
+		}
+		catch (MessagingException e) {
+			assertThat(e.getMessage())
+					.contains("Dispatcher has no subscribers for channel 'foo.noSubscribersChannel'.");
+		}
+	}
+
+	@Test
+	public void withNoContext() {
+		DirectChannel channel = new DirectChannel();
+		channel.setBeanName("bar");
+		try {
+			channel.send(new GenericMessage<String>("Hello, world!"));
+			fail("Exception expected");
+		}
+		catch (MessagingException e) {
+			assertThat(e.getMessage()).contains("Dispatcher has no subscribers for channel 'bar'.");
+		}
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/P2pChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/P2pChannelTests.java
@@ -41,6 +41,8 @@ import static org.mockito.Mockito.when;
  *
  */
 public class P2pChannelTests {
+	final MessageHandler handler1 = mock(MessageHandler.class);
+	final MessageHandler handler2 = mock(MessageHandler.class);
 
 	@Test
 	public void testDirectChannelLoggingWithMoreThenOneSubscriber() {
@@ -72,11 +74,9 @@ public class P2pChannelTests {
 				+ "' has "
 				+ "%d subscriber(s).";
 
-		MessageHandler handler1 = mock(MessageHandler.class);
 		channel.subscribe(handler1);
 		assertThat(channel.getSubscriberCount()).isEqualTo(1);
 		assertThat(logs.remove(0)).isEqualTo(String.format(log, 1));
-		MessageHandler handler2 = mock(MessageHandler.class);
 		channel.subscribe(handler2);
 		assertThat(channel.getSubscriberCount()).isEqualTo(2);
 		assertThat(logs.remove(0)).isEqualTo(String.format(log, 2));

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
@@ -60,7 +60,8 @@ import static org.mockito.Mockito.when;
 @SpringJUnitConfig
 @DirtiesContext
 public class HeaderChannelRegistryTests {
-
+	final BeanFactory beanFactory = mock(BeanFactory.class);
+	
 	@Autowired
 	MessageChannel input;
 
@@ -206,7 +207,6 @@ public class HeaderChannelRegistryTests {
 	@Test
 	public void testBFCRWithRegistry() {
 		BeanFactoryChannelResolver resolver = new BeanFactoryChannelResolver();
-		BeanFactory beanFactory = mock(BeanFactory.class);
 		when(beanFactory.getBean(IntegrationContextUtils.INTEGRATION_HEADER_CHANNEL_REGISTRY_BEAN_NAME,
 				HeaderChannelRegistry.class))
 				.thenReturn(mock(HeaderChannelRegistry.class));
@@ -223,7 +223,6 @@ public class HeaderChannelRegistryTests {
 	@Test
 	public void testBFCRNoRegistry() {
 		BeanFactoryChannelResolver resolver = new BeanFactoryChannelResolver();
-		BeanFactory beanFactory = mock(BeanFactory.class);
 		doAnswer(invocation -> {
 			throw new NoSuchBeanDefinitionException("bar");
 		}).when(beanFactory).getBean("foo", MessageChannel.class);

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -112,7 +112,9 @@ import static org.mockito.Mockito.verify;
 @DirtiesContext
 @ActiveProfiles("gatewayTest")
 public class GatewayInterfaceTests {
-
+	final MessageHandler handler = mock(MessageHandler.class);
+	final MessageHandler messageHandler = mock(MessageHandler.class);
+	
 	private static final String IGNORE_HEADER = "ignoreHeader";
 
 	@Autowired
@@ -220,7 +222,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelBar", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		bar.bar("hello");
@@ -279,7 +280,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelFoo", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Foo foo = ac.getBean(Foo.class);
 		foo.foo("hello");
@@ -292,7 +292,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Foo foo = ac.getBean(Foo.class);
 		foo.baz("hello");
@@ -305,7 +304,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		assertThat(ac.getBean(Bar.class).hashCode()).isEqualTo(bar.hashCode());
@@ -318,7 +316,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		bar.toString();
@@ -331,7 +328,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		assertThat(ac.getBean(Bar.class)).isSameAs(bar);
@@ -352,7 +348,6 @@ public class GatewayInterfaceTests {
 		ConfigurableApplicationContext ac =
 				new ClassPathXmlApplicationContext("GatewayInterfaceTests-context.xml", getClass());
 		DirectChannel channel = ac.getBean("requestChannelBaz", DirectChannel.class);
-		MessageHandler handler = mock(MessageHandler.class);
 		channel.subscribe(handler);
 		Bar bar = ac.getBean(Bar.class);
 		bar.getClass();
@@ -504,8 +499,6 @@ public class GatewayInterfaceTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testIgnoredHeader() {
-		MessageHandler messageHandler = mock(MessageHandler.class);
-
 		((SubscribableChannel) this.errorChannel).subscribe(messageHandler);
 		this.ignoredHeaderGateway.service("foo", "theHeaderValue");
 
@@ -546,8 +539,6 @@ public class GatewayInterfaceTests {
 	void primaryMarkerWins() {
 		PrimaryGateway primaryGateway = this.beanFactory.getBean(PrimaryGateway.class);
 		assertThat(AopUtils.isAopProxy(primaryGateway)).isTrue();
-
-		MessageHandler messageHandler = mock(MessageHandler.class);
 
 		((SubscribableChannel) this.errorChannel).subscribe(messageHandler);
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
